### PR TITLE
Add before & after methods, clean up interface and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## Aion
-Aion is a utility crate, inspired by rails, allow you to write `Duration` and `DateTime` in a friendly way: 
+Aion is a utility crate, inspired by rails, that allows you to write `Duration` and `DateTime` in a friendly way:
 ```rust
 let now = Utc::now();
 let two_days_later_1 = now + 2.days(); 
-let two_days_later_2 = 2.days().later();
+let two_days_later_2 = 2.days().from_now();
 ```
 
 ## Installation
@@ -19,14 +19,22 @@ use aion::*;
 use chrono::Utc;
 
 fn main() {
-  println!("2 days later: {}", 2.days().later());
-  println!("3 days ago: {}", 3.days().ago());
-  println!("3 days ago: {}", Utc::now() - 3.days());
-  println!("4 minutes later: {}", 4.minutes().later());
-  println!("5 weeks later: {}", 5.weeks().later());
-  println!("6 seconds ago: {}", 6.seconds().ago());
-  println!("7 days from now: {}", 7.days().from_now());
-  println!("8 milliseconds later: {}", 8.milliseconds().later());
+    println!("2 days from now: {}", 2.days().from_now());
+    println!("3 days ago: {}", 3.days().ago());
+    println!("3 days ago: {}", Utc::now() - 3.days());
+    println!("4 minutes from now: {}", 4.minutes().from_now());
+    println!("5 weeks from now: {}", 5.weeks().from_now());
+    println!("6 seconds ago: {}", 6.seconds().ago());
+    println!("7 days from now: {}", 7.days().from_now());
+    println!("8 milliseconds from now: {}", 8.milliseconds().from_now());
+    println!(
+        "5 days ago + 9 microseconds: {}",
+        9.microseconds().after(5.days().ago())
+    );
+    println!(
+        "2 weeks from now - 10 nanoseconds: {}",
+        10.nanoseconds().before(2.weeks().from_now())
+    );
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 ## Aion
 Aion is a utility crate, inspired by rails, that allows you to write `Duration` and `DateTime` in a friendly way:
 ```rust
-let now = Utc::now();
-let two_days_later_1 = now + 2.days(); 
-let two_days_later_2 = 2.days().from_now();
+// Easily represent a chrono::Duration
+let two_days = 2.days();
+let attention_span = 1.seconds();
+
+// Add or subtract durations from the current time (UTC)
+let two_hours_from_now = 2.hours().from_now();
+let last_week = 7.days().ago(); // or 1.weeks().ago()
+
+// More complex DateTimes can be represented using before() and after() methods
+let christmas = Utc.ymd(2020, 12, 25).and_hms(0, 0, 0);
+let two_weeks_before_christmas = 2.weeks().before(christmas);
+let boxing_day = 1.days().after(christmas);
 ```
 
 ## Installation
@@ -11,31 +20,6 @@ Add this to your `Cargo.toml` file:
 ```toml
 [dependencies]
 aion = "0.1"
-```
-
-## Example
-```rust
-use aion::*;
-use chrono::Utc;
-
-fn main() {
-    println!("2 days from now: {}", 2.days().from_now());
-    println!("3 days ago: {}", 3.days().ago());
-    println!("3 days ago: {}", Utc::now() - 3.days());
-    println!("4 minutes from now: {}", 4.minutes().from_now());
-    println!("5 weeks from now: {}", 5.weeks().from_now());
-    println!("6 seconds ago: {}", 6.seconds().ago());
-    println!("7 days from now: {}", 7.days().from_now());
-    println!("8 milliseconds from now: {}", 8.milliseconds().from_now());
-    println!(
-        "5 days ago + 9 microseconds: {}",
-        9.microseconds().after(5.days().ago())
-    );
-    println!(
-        "2 weeks from now - 10 nanoseconds: {}",
-        10.nanoseconds().before(2.weeks().from_now())
-    );
-}
 ```
 
 ## Limitations

--- a/example/main.rs
+++ b/example/main.rs
@@ -2,12 +2,12 @@ use aion::*;
 use chrono::Utc;
 
 fn main() {
-    println!("2 days later: {}", 2.days().later());
+    println!("2 days from now: {}", 2.days().from_now());
     println!("3 days ago: {}", 3.days().ago());
     println!("3 days ago: {}", Utc::now() - 3.days());
-    println!("4 minutes later: {}", 4.minutes().later());
-    println!("5 weeks later: {}", 5.weeks().later());
+    println!("4 minutes from now: {}", 4.minutes().from_now());
+    println!("5 weeks from now: {}", 5.weeks().from_now());
     println!("6 seconds ago: {}", 6.seconds().ago());
     println!("7 days from now: {}", 7.days().from_now());
-    println!("8 milliseconds later: {}", 8.milliseconds().later());
+    println!("8 milliseconds from now: {}", 8.milliseconds().from_now());
 }

--- a/example/main.rs
+++ b/example/main.rs
@@ -10,4 +10,12 @@ fn main() {
     println!("6 seconds ago: {}", 6.seconds().ago());
     println!("7 days from now: {}", 7.days().from_now());
     println!("8 milliseconds from now: {}", 8.milliseconds().from_now());
+    println!(
+        "5 days ago + 9 microseconds: {}",
+        9.microseconds().after(5.days().ago())
+    );
+    println!(
+        "2 weeks from now - 10 nanoseconds: {}",
+        10.nanoseconds().before(2.weeks().from_now())
+    );
 }

--- a/example/main.rs
+++ b/example/main.rs
@@ -1,21 +1,23 @@
 use aion::*;
-use chrono::Utc;
+use chrono::{TimeZone, Utc};
 
 fn main() {
-    println!("2 days from now: {}", 2.days().from_now());
-    println!("3 days ago: {}", 3.days().ago());
-    println!("3 days ago: {}", Utc::now() - 3.days());
-    println!("4 minutes from now: {}", 4.minutes().from_now());
-    println!("5 weeks from now: {}", 5.weeks().from_now());
-    println!("6 seconds ago: {}", 6.seconds().ago());
-    println!("7 days from now: {}", 7.days().from_now());
-    println!("8 milliseconds from now: {}", 8.milliseconds().from_now());
-    println!(
-        "5 days ago + 9 microseconds: {}",
-        9.microseconds().after(5.days().ago())
-    );
-    println!(
-        "2 weeks from now - 10 nanoseconds: {}",
-        10.nanoseconds().before(2.weeks().from_now())
-    );
+    // Easily represent a chrono::Duration
+    let two_days = 2.days();
+    println!("2 days: {:?}", two_days);
+    let attention_span = 1.seconds();
+    println!("Attention span: {:?}", attention_span);
+
+    // Add or subtract durations from the current time (UTC)
+    let two_hours_from_now = 2.hours().from_now();
+    println!("2 hours from now: {}", two_hours_from_now);
+    let last_week = 7.days().ago(); // or 1.weeks().ago()
+    println!("1 week ago: {}", last_week);
+
+    // More complex DateTimes can be represented using before() and after() methods
+    let christmas = Utc.ymd(2020, 12, 25).and_hms(0, 0, 0);
+    let two_weeks_before_christmas = 2.weeks().before(christmas);
+    println!("2 weeks before christmas: {}", two_weeks_before_christmas);
+    let boxing_day = 1.days().after(christmas);
+    println!("Boxing day: {}", boxing_day);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,22 @@ pub trait DurationExtension {
 }
 
 pub trait DateTimeExtension {
-    fn ago(self) -> DateTime<Utc>;
-    fn later(self) -> DateTime<Utc>;
-    fn from_now(self) -> DateTime<Utc>;
+    fn before(self, other: DateTime<Utc>) -> DateTime<Utc>;
+    fn after(self, other: DateTime<Utc>) -> DateTime<Utc>;
+
+    fn ago(self) -> DateTime<Utc>
+    where
+        Self: DateTimeExtension + Sized,
+    {
+        self.before(Utc::now())
+    }
+
+    fn from_now(self) -> DateTime<Utc>
+    where
+        Self: DateTimeExtension + Sized,
+    {
+        self.after(Utc::now())
+    }
 }
 
 impl DurationExtension for i64 {
@@ -52,16 +65,12 @@ impl DurationExtension for i64 {
 }
 
 impl DateTimeExtension for Duration {
-    fn ago(self) -> DateTime<Utc> {
-        Utc::now() - self
+    fn before(self, other: DateTime<Utc>) -> DateTime<Utc> {
+        other - self
     }
 
-    fn later(self) -> DateTime<Utc> {
-        Utc::now() + self
-    }
-
-    fn from_now(self) -> DateTime<Utc> {
-        Utc::now() + self
+    fn after(self, other: DateTime<Utc>) -> DateTime<Utc> {
+        other + self
     }
 }
 
@@ -69,11 +78,6 @@ impl DateTimeExtension for Duration {
 mod tests {
     use super::*;
     use chrono::{Duration, Utc};
-
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
 
     #[test]
     fn duration() {
@@ -85,12 +89,14 @@ mod tests {
     }
 
     #[test]
-    fn days_later() {
-        assert_eq!(2.days().later(), Utc::now() + Duration::days(2));
+    fn days_before() {
+        let now = Utc::now();
+        assert_eq!(2.days().before(now), now - Duration::days(2));
     }
 
     #[test]
-    fn days_ago() {
-        assert_eq!(2.days().ago(), Utc::now() - Duration::days(2));
+    fn days_after() {
+        let now = Utc::now();
+        assert_eq!(2.days().after(now), now + Duration::days(2));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,9 @@ mod tests {
         assert_eq!(2.hours(), Duration::hours(2));
         assert_eq!(2.minutes(), Duration::minutes(2));
         assert_eq!(2.seconds(), Duration::seconds(2));
+        assert_eq!(2.milliseconds(), Duration::milliseconds(2));
+        assert_eq!(2.microseconds(), Duration::microseconds(2));
+        assert_eq!(2.nanoseconds(), Duration::nanoseconds(2));
     }
 
     #[test]


### PR DESCRIPTION
The `days_later` and `days_ago` tests were failing since there is a small execution delay between the evaluation of each side of the equality assertion. We _could_ just calculate the difference between the two values and then assert that it is small enough to consider the two sides equal, but a better solution is to implement a `before` and an `after` method to modify a given `DateTime`. Then the `ago` and `from_now` methods can be automatically implemented using `before` and `after`. 

This also gives us a more expressive way to write more complex `DateTime`s, like `10.weeks().before(20.minutes().ago())`.

Other changes:
- Removed `later` method since it's equivalent to `from_now`
- Updated README and examples